### PR TITLE
silence warnings appearing because of wextra

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -31,6 +31,9 @@ set(OBJECT_NAME ne10)
 # Object file name in the file manager
 set(OBJECT_FILE_NAME _${OBJECT_NAME}_all_${VARIANT})
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-old-style-declaration")
+add_compile_options(-Wno-sign-compare)
+
 # Define Function Enabling Macros
 include(../cmake/FunctionSwitch.cmake)
 


### PR DESCRIPTION
**What** : Silent some warnings
**Why** : Appeared because of `-Wextra` added in the C-SDK but that's not our code so we just silent them