### PR TITLE
fixing compilation for arm cortex A7

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -32,7 +32,7 @@ set(OBJECT_NAME ne10)
 set(OBJECT_FILE_NAME _${OBJECT_NAME}_all_${VARIANT})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-old-style-declaration")
-add_compile_options(-Wno-sign-compare)
+add_compile_options(-Wno-sign-compare -fno-strict-aliasing)
 
 # Define Function Enabling Macros
 include(../cmake/FunctionSwitch.cmake)


### PR DESCRIPTION
**What** : Remove warnings
**Why** : We don't handle warning fixes and we trust the library