### PR TITLE
Add support for CPUs with a larger cpuinfo size due to more features on modern CPUs

### DIFF
--- a/modules/NE10_init.c
+++ b/modules/NE10_init.c
@@ -31,7 +31,7 @@
 
 #include "NE10.h"
 
-#define CPUINFO_BUFFER_SIZE  (1024*4)
+#define CPUINFO_BUFFER_SIZE  (1024*5)
 
 // This local variable indicates whether or not the running platform supports ARM NEON
 ne10_result_t is_NEON_available = NE10_ERR;


### PR DESCRIPTION
### Summary

Samsung Galaxy S24 (International model SM-S921-B) cannot read `/proc/cpuinfo` file because its contents are larger than what our buffer to hold it is.

This change bumps the size of our buffer from 4K to 5K.

### Testing

Verified that a Google Pixel 8 Pro and the Samsung Galaxy S24 (SM-S921-B) can now both succeed at reading the `/proc/cpuinfo` file.